### PR TITLE
홈페이지가 잘못 기입된 오타를 수정

### DIFF
--- a/Formula/dhapi.rb
+++ b/Formula/dhapi.rb
@@ -1,6 +1,6 @@
 class Dhapi < Formula
     desc "DongHang Lottery API (Unofficial)"
-    homepage "https://github.com/roeniss/dhlottery-pai"
+    homepage "https://github.com/roeniss/dhlottery-api"
     url "https://github.com/roeniss/dhlottery-api/releases/download/v1.0.9/dhapi-mac.tar.gz"
     sha256 "8bc16db544ae20434b0b04e06d4f90d8699d634e183fb5f42fe1d5c4c840e6ce"
     version "1.0.9"


### PR DESCRIPTION
`homepage "https://github.com/roeniss/dhlottery-api"` 로 수정처리 PR 드립니다.